### PR TITLE
Added linktree page link to sidebar on every page

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -27,6 +27,7 @@
                         <li><a href="images/Shaikh Minhaj Resume.pdf" target="_blank">Resume</a></li></a>
                         <li><a href="blog.html">Blog</li></a>
                         <li><a href="contact.html">Contact Me</li></a>
+                        <li><a href="linktree.html">Links</li></a>
                     </ul>
             </nav>
         </div>

--- a/contact.html
+++ b/contact.html
@@ -25,6 +25,7 @@
             <li><a href="images/Shaikh Minhaj Resume.pdf" target="_blank">Resume</a></li></a>
             <li><a href="blog.html">Blog</li></a>
             <li><a href="contact.html">Contact Me</li></a>
+            <li><a href="linktree.html">Links</li></a>
           </ul>
       </nav>
     </div>

--- a/intro.html
+++ b/intro.html
@@ -26,6 +26,7 @@
                         <li><a href="images/Shaikh Minhaj Resume.pdf" target="_blank">Resume</a></li></a>
                         <li><a href="blog.html">Blog</li></a>
                         <li><a href="contact.html">Contact Me</li></a>
+                        <li><a href="linktree.html">Links</li></a>
                     </ul>
             </nav>
         </div>

--- a/services.html
+++ b/services.html
@@ -26,6 +26,7 @@
                         <li><a href="images/Shaikh Minhaj Resume.pdf" target="_blank">Resume</a></li></a>
                         <li><a href="blog.html">Blog</li></a>
                         <li><a href="contact.html">Contact Me</li></a>
+                        <li><a href="linktree.html">Links</li></a>
                     </ul>
             </nav>
         </div>


### PR DESCRIPTION
After these changes, portfolio visitors can be able to see the linktree page from any of the pages they are currently on, so that they would not always have to go to the Home page to go on linktree page.

Eg,

Here added the Links tab in the sidebar on each of the pages which serves the purpose.

Images after implementing these changes.
Intro Page:
![image](https://user-images.githubusercontent.com/68096217/194122117-25b4fbd4-cbba-4d9e-9147-916834a377e6.png)

Services Page:
![image](https://user-images.githubusercontent.com/68096217/194122162-c2942afc-e91e-47d1-8453-cf12fd77995f.png)

Blogs Page:
![image](https://user-images.githubusercontent.com/68096217/194122210-d8d29975-1ea6-4154-91ae-f6462ace931f.png)

Contact Page:
![image](https://user-images.githubusercontent.com/68096217/194122275-6d505787-0afb-4e29-bac9-9b9ddaba162d.png)
