### PR TITLE
Updated styling (changes.css) for intro.html #17

### DIFF
--- a/changes.css
+++ b/changes.css
@@ -1,5 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Fira+Sans&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Fira+Sans&family=Source+Code+Pro:wght@300&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;700&display=swap");
 
 * {
   margin: 0;
@@ -75,6 +76,8 @@ body {
   color: rgb(0, 0, 0);
   display: block;
   transition: 0.3s;
+  position: relative;
+  font-family: "Montserrat", sans-serif;
 }
 
 .sidebar a:hover {
@@ -103,6 +106,23 @@ body {
   /* float: left;*/
 }
 
+
+/*sidebar hover effect starts*/
+.sidebar a::after{
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 0.175rem;
+  left: 0;
+  bottom: 0;
+  background: #0000ff;
+  transform: scale(0,1);
+  transition: transform 0.5s ease;
+}
+
+.sidebar a:hover::after{
+  transform: scale(1,1);
+}
 
 #main {
   transition: margin-left 0.5s;


### PR DESCRIPTION
Added styling in the changes.css file to keep the sidebar for the intro.html page in sync with other pages.

For eg.,

Before:
![image](https://user-images.githubusercontent.com/68096217/194132011-91403400-155e-46e0-89f0-9c0e702ecd82.png)

After:
![image](https://user-images.githubusercontent.com/68096217/194132080-d284bc39-045d-4c2c-bb1e-bc6ec17843cc.png)

Thank you.